### PR TITLE
Adjust FloatBorder highlight group foreground

### DIFF
--- a/lua/everblush/config.lua
+++ b/lua/everblush/config.lua
@@ -22,7 +22,7 @@ M.highlights_base = function (colors)
     Folded = { fg = colors.color4, bg = colors.background },
     FoldColumn = { fg = colors.color4, bg = colors.background },
     LineNr = { fg = colors.color0, bg = colors.background },
-    FloatBorder = { fg = colors.background, bg = colors.background },
+    FloatBorder = { fg = colors.foreground, bg = colors.background },
     Whitespace = { fg = colors.color1 },
     VertSplit = { fg = colors.background, bg = colors.color0 },
     CursorLine = { bg = colors.cursorline },


### PR DESCRIPTION
fixes #10, by changing the `fg` color of FloatBorder from `colors.background` to `colors.foreground`, so that it can be seen.