### PR TITLE
fix: Carets (^) in Status Line

### DIFF
--- a/lua/everblush/config.lua
+++ b/lua/everblush/config.lua
@@ -4,7 +4,7 @@ M.highlights_base = function (colors)
   return {
     Normal = { fg = colors.foreground, bg = colors.background },
     StatusLineNC = { bg = colors.background, fg = colors.background },
-    StatusLine = { bg = colors.background, fg = colors.background },
+    StatusLine = { bg = "none", fg = "none" },
     SignColumn = { bg = colors.background, fg = colors.background },
     MsgArea = { fg = colors.foreground, bg = colors.background },
     ModeMsg = { fg = colors.foreground, bg = colors.background },


### PR DESCRIPTION
When the screen is split multiple carets (^) appear in the Status Line. According to the reference manual this is because the StatusLine value is identical to StatusLineNC.

The reference manual can be reviewed with the command: `help StatusLineNC `

Before:
![image](https://user-images.githubusercontent.com/70251272/197310856-bf03ee7c-cf6c-4b04-9b5d-761fd9b69caf.png)

After:
![image](https://user-images.githubusercontent.com/70251272/197310812-deaf0c59-11fb-494a-90c3-2ea2a30722ac.png)

