### PR TITLE
fix: superfluous highlighting of indent-blankline.nvim

### DIFF
--- a/lua/everblush/config.lua
+++ b/lua/everblush/config.lua
@@ -212,7 +212,7 @@ M.highlights_base = function (colors)
     TelescopeSelection = { fg = colors.background, bg = colors.color5 },
 
     -- Indent Blank Line
-    IndentBlanklineChar = { fg = colors.color0, bg = colors.background },
+    IndentBlanklineChar = { fg = colors.color0 },
 
     -- NvimTree
     NvimTreeNormal = { fg = colors.foreground, bg = colors.background },


### PR DESCRIPTION
before:
![before](https://user-images.githubusercontent.com/105504350/208706897-20512592-cef3-4948-9408-60599b7fb940.png)

after:
![after](https://user-images.githubusercontent.com/105504350/208706950-cfd96c5c-0517-4e4e-8fb1-0fb8e0bb7a7b.png)
